### PR TITLE
Endpoints return only base order information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ New functionality added in a backwards-compatible manner:
 * [OLMIS-2551](https://openlmis.atlassian.net/browse/OLMIS-2551): Added an endpoint for batch
 order creation, which allows creating multiple orders in one transaction.
 * [OLMIS-2611](https://openlmis.atlassian.net/browse/OLMIS-2611): Added using locale from env file.
+* Order endpoints (except for */orders/{id}*) will now return new, smaller Dto object, which only
+contains basic information about the order.
+* A single request with orderable IDs will be sent to reference-data service when Order Dto object
+is created.
+* Set *LAZY* flag for all collections inside Order and Proof of Delivery classes.
 
 3.0.3 / 2017-05-26
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ New functionality added in a backwards-compatible manner:
 * [OLMIS-2551](https://openlmis.atlassian.net/browse/OLMIS-2551): Added an endpoint for batch
 order creation, which allows creating multiple orders in one transaction.
 * [OLMIS-2611](https://openlmis.atlassian.net/browse/OLMIS-2611): Added using locale from env file.
-* Order endpoints (except for */orders/{id}*) will now return new, smaller Dto object, which only
-contains basic information about the order.
 * A single request with orderable IDs will be sent to reference-data service when Order Dto object
 is created.
 * Set *LAZY* flag for all collections inside Order and Proof of Delivery classes.
+
+Contract breaking changes:
+* Order endpoints (except for */orders/{id}*) will now return new, smaller Dto object, which only
+contains basic information about the order.
 
 3.0.3 / 2017-05-26
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-3.1.0 / WIP
+4.0.0 / WIP
 ==================
 
 New functionality added in a backwards-compatible manner:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ serviceName=openlmis-fulfillment
 # Only a Release Manager should update this
 # See https://openlmis.atlassian.net/wiki/display/OP/Rolling+a+Release
 ######################################################################
-serviceVersion=3.1.0-SNAPSHOT
+serviceVersion=4.0.0-SNAPSHOT

--- a/src/integration-test/java/org/openlmis/fulfillment/web/OrderControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/web/OrderControllerIntegrationTest.java
@@ -57,6 +57,7 @@ import org.openlmis.fulfillment.service.OrderFileStorage;
 import org.openlmis.fulfillment.service.OrderFtpSender;
 import org.openlmis.fulfillment.service.ResultDto;
 import org.openlmis.fulfillment.service.notification.NotificationService;
+import org.openlmis.fulfillment.web.util.BasicOrderDto;
 import org.openlmis.fulfillment.web.util.OrderDto;
 import org.openlmis.fulfillment.web.util.ProofOfDeliveryDto;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -126,8 +127,8 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
   private Order secondOrder = new Order();
   private Order thirdOrder = new Order();
 
-  private OrderDto firstOrderDto;
-  private OrderDto secondOrderDto;
+  private BasicOrderDto firstOrderDto;
+  private BasicOrderDto secondOrderDto;
 
   @Before
   public void setUp() {
@@ -158,8 +159,8 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
     firstOrder.setOrderLineItems(orderLineItems);
     firstOrder.setExternalId(secondOrder.getExternalId());
 
-    firstOrderDto = OrderDto.newInstance(firstOrder, exporter);
-    secondOrderDto = OrderDto.newInstance(secondOrder, exporter);
+    firstOrderDto = BasicOrderDto.newInstance(firstOrder, exporter);
+    secondOrderDto = BasicOrderDto.newInstance(secondOrder, exporter);
 
     given(orderRepository.findAll()).willReturn(
         Lists.newArrayList(firstOrder, secondOrder, thirdOrder)
@@ -281,12 +282,12 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
         .statusCode(200)
         .extract().as(PageImplRepresentation.class);
 
-    List<OrderDto> content = getPageContent(response, OrderDto.class);
+    List<BasicOrderDto> content = getPageContent(response, BasicOrderDto.class);
 
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
     assertThat(content, hasSize(1));
 
-    for (OrderDto order : content) {
+    for (BasicOrderDto order : content) {
       assertEquals(
           order.getSupplyingFacility().getId(),
           firstOrder.getSupplyingFacilityId());
@@ -312,12 +313,12 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
         .statusCode(200)
         .extract().as(PageImplRepresentation.class);
 
-    List<OrderDto> content = getPageContent(response, OrderDto.class);
+    List<BasicOrderDto> content = getPageContent(response, BasicOrderDto.class);
 
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
     assertThat(content, hasSize(1));
 
-    for (OrderDto order : content) {
+    for (BasicOrderDto order : content) {
       assertEquals(
           order.getSupplyingFacility().getId(),
           firstOrder.getSupplyingFacilityId());
@@ -349,12 +350,12 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
         .statusCode(200)
         .extract().as(PageImplRepresentation.class);
 
-    List<OrderDto> content = getPageContent(response, OrderDto.class);
+    List<BasicOrderDto> content = getPageContent(response, BasicOrderDto.class);
 
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
     assertThat(content, hasSize(1));
 
-    for (OrderDto order : content) {
+    for (BasicOrderDto order : content) {
       assertEquals(
           order.getSupplyingFacility().getId(),
           firstOrder.getSupplyingFacilityId());
@@ -391,12 +392,12 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
         .statusCode(200)
         .extract().as(PageImplRepresentation.class);
 
-    List<OrderDto> content = getPageContent(response, OrderDto.class);
+    List<BasicOrderDto> content = getPageContent(response, BasicOrderDto.class);
 
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
     assertThat(content, hasSize(1));
 
-    for (OrderDto order : content) {
+    for (BasicOrderDto order : content) {
       assertEquals(
           order.getSupplyingFacility().getId(),
           firstOrder.getSupplyingFacilityId());
@@ -431,11 +432,11 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
         .statusCode(200)
         .extract().as(PageImplRepresentation.class);
 
-    List<OrderDto> content = getPageContent(response, OrderDto.class);
+    List<BasicOrderDto> content = getPageContent(response, BasicOrderDto.class);
 
     assertThat(content, hasSize(2));
 
-    for (OrderDto order : content) {
+    for (BasicOrderDto order : content) {
       assertThat(order.getStatus(), isOneOf(READY_TO_PACK, IN_ROUTE));
     }
 
@@ -457,7 +458,7 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
         .statusCode(200)
         .extract().as(PageImplRepresentation.class);
 
-    List<OrderDto> content = getPageContent(response, OrderDto.class);
+    List<BasicOrderDto> content = getPageContent(response, BasicOrderDto.class);
 
     assertThat(content, hasSize(1));
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
@@ -489,12 +490,12 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
         .statusCode(200)
         .extract().as(PageImplRepresentation.class);
 
-    List<OrderDto> content = getPageContent(response, OrderDto.class);
+    List<BasicOrderDto> content = getPageContent(response, BasicOrderDto.class);
 
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
     assertThat(content, hasSize(1));
 
-    for (OrderDto order : content) {
+    for (BasicOrderDto order : content) {
       assertEquals(
           order.getSupplyingFacility().getId(),
           firstOrder.getSupplyingFacilityId());
@@ -536,7 +537,7 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
   public void shouldCreateOrder() {
     firstOrder.getOrderLineItems().clear();
     firstOrder.setSupplyingFacilityId(UUID.fromString(FACILITY_ID));
-    firstOrderDto = OrderDto.newInstance(firstOrder, exporter);
+    firstOrderDto = BasicOrderDto.newInstance(firstOrder, exporter);
 
     restAssured.given()
         .queryParam(ACCESS_TOKEN, getToken())
@@ -579,16 +580,16 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
   @Test
   public void shouldGetAllOrders() {
 
-    OrderDto[] response = restAssured.given()
+    BasicOrderDto[] response = restAssured.given()
         .queryParam(ACCESS_TOKEN, getToken())
         .contentType(APPLICATION_JSON_VALUE)
         .when()
         .get(RESOURCE_URL)
         .then()
         .statusCode(200)
-        .extract().as(OrderDto[].class);
+        .extract().as(BasicOrderDto[].class);
 
-    Iterable<OrderDto> orders = asList(response);
+    Iterable<BasicOrderDto> orders = asList(response);
     assertTrue(orders.iterator().hasNext());
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
   }
@@ -636,7 +637,7 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
 
     given(orderRepository.findOne(firstOrder.getId())).willReturn(firstOrder);
     firstOrder.setOrderLineItems(null);
-    firstOrderDto = OrderDto.newInstance(firstOrder, exporter);
+    firstOrderDto = BasicOrderDto.newInstance(firstOrder, exporter);
 
     restAssured.given()
         .queryParam(ACCESS_TOKEN, getToken())

--- a/src/main/java/org/openlmis/fulfillment/web/OrderController.java
+++ b/src/main/java/org/openlmis/fulfillment/web/OrderController.java
@@ -39,6 +39,7 @@ import org.openlmis.fulfillment.service.TemplateService;
 import org.openlmis.fulfillment.service.referencedata.ProgramDto;
 import org.openlmis.fulfillment.service.referencedata.ProgramReferenceDataService;
 import org.openlmis.fulfillment.util.Pagination;
+import org.openlmis.fulfillment.web.util.BasicOrderDto;
 import org.openlmis.fulfillment.web.util.OrderDto;
 import org.openlmis.fulfillment.web.util.ProofOfDeliveryDto;
 import org.slf4j.Logger;
@@ -125,7 +126,8 @@ public class OrderController extends BaseController {
   @RequestMapping(value = "/orders", method = RequestMethod.POST)
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
-  public OrderDto createOrder(@RequestBody OrderDto orderDto, OAuth2Authentication authentication) {
+  public BasicOrderDto createOrder(@RequestBody OrderDto orderDto,
+                                   OAuth2Authentication authentication) {
     return createSingleOrder(orderDto, authentication);
   }
 
@@ -139,12 +141,12 @@ public class OrderController extends BaseController {
   @RequestMapping(value = "/orders/batch", method = RequestMethod.POST)
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
-  public List<OrderDto> batchCreateOrders(@RequestBody List<OrderDto> orders,
-                              OAuth2Authentication authentication) {
-    List<OrderDto> newOrders = new ArrayList<>();
+  public List<BasicOrderDto> batchCreateOrders(@RequestBody List<OrderDto> orders,
+                                               OAuth2Authentication authentication) {
+    List<BasicOrderDto> newOrders = new ArrayList<>();
 
     for (OrderDto order : orders) {
-      OrderDto newOrder = createSingleOrder(order, authentication);
+      BasicOrderDto newOrder = createSingleOrder(order, authentication);
       newOrders.add(newOrder);
     }
 
@@ -158,8 +160,8 @@ public class OrderController extends BaseController {
    */
   @RequestMapping(value = "/orders", method = RequestMethod.GET)
   @ResponseBody
-  public Iterable<OrderDto> getAllOrders() {
-    return OrderDto.newInstance(orderRepository.findAll(), exporter);
+  public Iterable<BasicOrderDto> getAllOrders() {
+    return BasicOrderDto.newInstance(orderRepository.findAll(), exporter);
   }
 
   /**
@@ -182,13 +184,13 @@ public class OrderController extends BaseController {
   /**
    * Finds Orders matching all of provided parameters.
    *
-   * @param params  provided parameters.
+   * @param params provided parameters.
    * @return ResponseEntity with list of all Orders matching provided parameters and OK httpStatus.
    */
   @RequestMapping(value = "/orders/search", method = RequestMethod.GET)
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public Page<OrderDto> searchOrders(OrderSearchParams params, Pageable pageable) {
+  public Page<BasicOrderDto> searchOrders(OrderSearchParams params, Pageable pageable) {
     List<Order> orders = orderService
         .searchOrders(params)
         .stream()
@@ -197,14 +199,14 @@ public class OrderController extends BaseController {
         .sorted((o1, o2) -> ObjectUtils.compare(o1.getId(), o2.getId()))
         .collect(Collectors.toList());
 
-    return Pagination.getPage(OrderDto.newInstance(orders, exporter), pageable);
+    return Pagination.getPage(BasicOrderDto.newInstance(orders, exporter), pageable);
   }
 
   /**
    * Returns csv or pdf of defined object in response.
    *
-   * @param orderId  UUID of order to print
-   * @param format   String describing return format (pdf or csv)
+   * @param orderId UUID of order to print
+   * @param format  String describing return format (pdf or csv)
    */
   @RequestMapping(value = "/orders/{id}/print", method = RequestMethod.GET)
   @ResponseStatus(HttpStatus.OK)
@@ -336,8 +338,8 @@ public class OrderController extends BaseController {
     );
   }
 
-  private OrderDto createSingleOrder(OrderDto orderDto,
-                                     OAuth2Authentication authentication) {
+  private BasicOrderDto createSingleOrder(OrderDto orderDto,
+                                          OAuth2Authentication authentication) {
     Order order = Order.newInstance(orderDto);
 
     if (!authentication.isClientOnly()) {
@@ -359,6 +361,6 @@ public class OrderController extends BaseController {
     proofOfDeliveryRepository.save(proofOfDelivery);
 
     LOGGER.debug("Created new order with id: {}", order.getId());
-    return OrderDto.newInstance(newOrder, exporter);
+    return BasicOrderDto.newInstance(newOrder, exporter);
   }
 }

--- a/src/main/java/org/openlmis/fulfillment/web/util/BasicOrderDto.java
+++ b/src/main/java/org/openlmis/fulfillment/web/util/BasicOrderDto.java
@@ -1,0 +1,133 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.fulfillment.web.util;
+
+
+import org.openlmis.fulfillment.domain.Order;
+import org.openlmis.fulfillment.domain.OrderStatus;
+import org.openlmis.fulfillment.service.ExporterBuilder;
+import org.openlmis.fulfillment.service.referencedata.FacilityDto;
+import org.openlmis.fulfillment.service.referencedata.ProcessingPeriodDto;
+import org.openlmis.fulfillment.service.referencedata.ProgramDto;
+import org.openlmis.fulfillment.service.referencedata.UserDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class BasicOrderDto implements Order.Exporter {
+
+  @Getter
+  @Setter
+  private UUID id;
+
+  @Getter
+  @Setter
+  private UUID externalId;
+
+  @Getter
+  @Setter
+  private Boolean emergency;
+
+  @Getter
+  @Setter
+  private FacilityDto facility;
+
+  @Getter
+  @Setter
+  private ProcessingPeriodDto processingPeriod;
+
+  @Getter
+  @Setter
+  private ZonedDateTime createdDate;
+
+  @Getter
+  @Setter
+  private UserDto createdBy;
+
+  @Getter
+  @Setter
+  private ProgramDto program;
+
+  @Getter
+  @Setter
+  private FacilityDto requestingFacility;
+
+  @Getter
+  @Setter
+  private FacilityDto receivingFacility;
+
+  @Getter
+  @Setter
+  private FacilityDto supplyingFacility;
+
+  @Getter
+  @Setter
+  private String orderCode;
+
+  @Getter
+  @Setter
+  private OrderStatus status;
+
+  @Getter
+  @Setter
+  private BigDecimal quotedCost;
+
+  @Override
+  public void setStatusMessages(List<StatusMessageDto> statusMessages) {
+    // nothing to do here
+  }
+
+  @Override
+  public void setStatusChanges(List<StatusChangeDto> statusChanges) {
+    // nothing to do here
+  }
+
+  /**
+   * Create new list of OrderDto based on list of {@link Order}
+   * @param orders list on orders
+   * @return list of OrderDto.
+   */
+  public static Iterable<BasicOrderDto> newInstance(Iterable<Order> orders,
+                                               ExporterBuilder exporter) {
+    List<BasicOrderDto> orderDtos = new ArrayList<>();
+    orders.forEach(o -> orderDtos.add(newInstance(o, exporter)));
+    return orderDtos;
+  }
+
+  /**
+   * Create new instance of OrderDto based on given {@link Order}
+   * @param order instance of Order
+   * @return new instance od OrderDto.
+   */
+  public static BasicOrderDto newInstance(Order order, ExporterBuilder exporter) {
+    BasicOrderDto orderDto =  new BasicOrderDto();
+    exporter.export(order, orderDto);
+
+    return orderDto;
+  }
+  
+}

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -10,6 +10,13 @@ documentation:
       content: Welcome to the OpenLMIS fulfillment-service documentation.
 
 schemas:
+  - basicOrderDto: !include schemas/basicOrderDto.json
+  - basicOrderDtoPage: !include schemas/orderDtoPage.json
+  - basicOrderDtoArray: |
+      {
+          "type": "array",
+          "items": {"type": "object", "$ref": "schemas/basicOrderDto.json" }
+      }
   - orderDto: !include schemas/orderDto.json
   - orderDtoPage: !include schemas/orderDtoPage.json
   - orderDtoArray: |
@@ -152,7 +159,7 @@ resourceTypes:
               200:
                   body:
                     application/json:
-                      schema: orderDtoArray
+                      schema: basicOrderDtoArray
               403:
                   body:
                     application/json:
@@ -167,7 +174,7 @@ resourceTypes:
               201:
                   body:
                     application/json:
-                      schema: orderDto
+                      schema: basicOrderDto
               409:
                   body:
                     application/json:
@@ -306,7 +313,7 @@ resourceTypes:
                       200:
                           body:
                             application/json:
-                              schema: orderDtoPage
+                              schema: basicOrderDtoPage
                       400:
                           body:
                             application/json:
@@ -353,7 +360,7 @@ resourceTypes:
                   201:
                       body:
                         application/json:
-                          schema: orderDtoArray
+                          schema: basicOrderDtoArray
                   409:
                       body:
                         application/json:

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -174,7 +174,7 @@ resourceTypes:
               201:
                   body:
                     application/json:
-                      schema: basicOrderDto
+                      schema: orderDto
               409:
                   body:
                     application/json:

--- a/src/main/resources/schemas/basicOrderDto.json
+++ b/src/main/resources/schemas/basicOrderDto.json
@@ -1,0 +1,88 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "OrderDto",
+  "description": "A single order created from requisition",
+  "properties": {
+    "id": {
+      "type": "string",
+      "title": "id"
+    },
+    "externalId": {
+      "type": "string",
+      "title": "externalId"
+    },
+    "emergency": {
+      "type": "boolean",
+      "title": "emergency"
+    },
+    "facility": {
+      "type": "object",
+      "title": "facility",
+      "$ref": "facilityDto.json"
+    },
+    "processingPeriod": {
+      "type": "object",
+      "title": "processingPeriod",
+      "$ref": "processingPeriodDto.json"
+    },
+    "createdDate": {
+      "type": "string",
+      "title": "createdDate"
+    },
+    "createdBy": {
+      "type": "object",
+      "title": "createdBy",
+      "$ref": "userDto.json"
+    },
+    "program": {
+      "type": "object",
+      "title": "program",
+      "$ref": "programDto.json"
+    },
+    "requestingFacility": {
+      "type": "object",
+      "title": "requestingFacility",
+      "$ref": "facilityDto.json"
+    },
+    "receivingFacility": {
+      "type": "object",
+      "title": "receivingFacility",
+      "$ref": "facilityDto.json"
+    },
+    "supplyingFacility": {
+      "type": "object",
+      "title": "supplyingFacility",
+      "$ref": "facilityDto.json"
+    },
+    "orderCode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "title": "orderCode"
+    },
+    "status": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "title": "status"
+    },
+    "quotedCost": {
+      "type": "number",
+      "title": "quotedCost"
+    }
+  },
+  "required": [
+    "id",
+    "externalId",
+    "emergency",
+    "createdBy",
+    "program",
+    "requestingFacility",
+    "receivingFacility",
+    "supplyingFacility",
+    "quotedCost"
+  ]
+}

--- a/src/main/resources/schemas/basicOrderDtoPage.json
+++ b/src/main/resources/schemas/basicOrderDtoPage.json
@@ -1,0 +1,61 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "Collection",
+  "description": "Paginated collection",
+  "properties": {
+    "content": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "basicOrderDto.json"
+      }
+    },
+    "totalPages": {
+      "type": "integer",
+      "title": "totalPages"
+    },
+    "totalElements": {
+      "type": "integer",
+      "title": "totalElements"
+    },
+    "size": {
+      "type": "integer",
+      "title": "size"
+    },
+    "number": {
+      "type": "integer",
+      "title": "number"
+    },
+    "numberOfElements": {
+      "type": "integer",
+      "title": "numberOfElements"
+    },
+    "last": {
+      "type": "boolean",
+      "title": "last"
+    },
+    "first": {
+      "type": "boolean",
+      "title": "first"
+    },
+    "sort?": {
+      "title": "sort",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "required": [
+    "content",
+    "totalPages",
+    "totalElements",
+    "totalElements",
+    "size",
+    "number",
+    "numberOfElements",
+    "first",
+    "last"
+  ]
+}


### PR DESCRIPTION
There is no need to return full order dto object for endpoints like create, batch create or search. The full order dto object is only return by **/order/{id}** endpoint. This should speed up endpoint execution.