### PR TITLE
Improve performance of view right checking for multiple orders

### DIFF
--- a/src/main/java/org/openlmis/fulfillment/service/OrderSecurityService.java
+++ b/src/main/java/org/openlmis/fulfillment/service/OrderSecurityService.java
@@ -1,0 +1,59 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.fulfillment.service;
+
+import org.openlmis.fulfillment.domain.Order;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class OrderSecurityService {
+
+  @Autowired
+  private PermissionService permissionService;
+
+  /**
+   * Filters orders based on user permissions. It strives to make as little calls to the
+   * reference data service as possible.
+   *
+   * @param orders input list containing any orders
+   * @return filtered input list of orders, containing only those that the user has access to
+   */
+  public List<Order> filterInaccessibleOrders(List<Order> orders) {
+    Map<UUID, Boolean> verified = new HashMap<>();
+    List<Order> filteredList = new ArrayList<>();
+
+    for (Order order : orders) {
+      Boolean accessible = verified.computeIfAbsent(
+          order.getSupplyingFacilityId(),
+          key -> permissionService.canViewOrderOrManagePod(order)
+      );
+
+      if (accessible) {
+        filteredList.add(order);
+      }
+    }
+
+    return filteredList;
+  }
+
+}

--- a/src/test/java/org/openlmis/fulfillment/service/OrderSecurityServiceTest.java
+++ b/src/test/java/org/openlmis/fulfillment/service/OrderSecurityServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.fulfillment.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openlmis.fulfillment.domain.Order;
+
+import java.util.List;
+import java.util.UUID;
+
+public class OrderSecurityServiceTest {
+
+  @Mock
+  private PermissionService permissionService;
+
+  @InjectMocks
+  private OrderSecurityService requisitionSecurityService = new OrderSecurityService();
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldUseCachedRightIfOneExists() {
+    final Order requisition = mockRequisition(UUID.randomUUID());
+
+    List<Order> allRequisitions = Lists.newArrayList(requisition, requisition, requisition);
+
+    requisitionSecurityService.filterInaccessibleOrders(allRequisitions);
+
+    // The permission service should be called only one time, despite having 3 requisitions, due
+    // to caching
+    verify(permissionService, times(1)).canViewOrderOrManagePod(any(Order.class));
+  }
+
+  @Test
+  public void shouldNotUseCachedRightIfAllCallsAreDifferent() {
+    final Order requisition = mockRequisition(UUID.randomUUID());
+    final Order requisition2 = mockRequisition(UUID.randomUUID());
+    final Order requisition3 = mockRequisition(UUID.randomUUID());
+
+    List<Order> allRequisitions = Lists.newArrayList(requisition, requisition2, requisition3);
+
+    requisitionSecurityService.filterInaccessibleOrders(allRequisitions);
+
+    // The permission service should be called one time for each requisition (no cache hits)
+    verify(permissionService, times(3)).canViewOrderOrManagePod(any(Order.class));
+  }
+
+  @Test
+  public void shouldProperlyFilterAccessibleRequisitions() {
+    final Order requisition = mockRequisition(UUID.randomUUID());
+    final Order requisition2 = mockRequisition(UUID.randomUUID());
+    final Order requisition3 = mockRequisition(UUID.randomUUID());
+    final Order requisition4 = mockRequisition(UUID.randomUUID());
+
+    when(permissionService.canViewOrderOrManagePod(any(Order.class)))
+        .thenReturn(true, false, false, true);
+
+    List<Order> allRequisitions = Lists.newArrayList(requisition, requisition2,
+        requisition3, requisition4);
+    List<Order> result = requisitionSecurityService
+        .filterInaccessibleOrders(allRequisitions);
+
+    assertEquals(2, result.size());
+    assertEquals(requisition, result.get(0));
+    assertEquals(requisition4, result.get(1));
+  }
+
+  private Order mockRequisition(UUID facilityId) {
+    Order requisition = new Order();
+    requisition.setSupplyingFacilityId(facilityId);
+    return requisition;
+  }
+}

--- a/src/test/java/org/openlmis/fulfillment/service/OrderSecurityServiceTest.java
+++ b/src/test/java/org/openlmis/fulfillment/service/OrderSecurityServiceTest.java
@@ -39,7 +39,7 @@ public class OrderSecurityServiceTest {
   private PermissionService permissionService;
 
   @InjectMocks
-  private OrderSecurityService requisitionSecurityService = new OrderSecurityService();
+  private OrderSecurityService orderSecurityService = new OrderSecurityService();
 
   @Before
   public void setUp() {
@@ -48,54 +48,52 @@ public class OrderSecurityServiceTest {
 
   @Test
   public void shouldUseCachedRightIfOneExists() {
-    final Order requisition = mockRequisition(UUID.randomUUID());
+    final Order order = mockOrder(UUID.randomUUID());
 
-    List<Order> allRequisitions = Lists.newArrayList(requisition, requisition, requisition);
+    List<Order> orders = Lists.newArrayList(order, order, order);
 
-    requisitionSecurityService.filterInaccessibleOrders(allRequisitions);
+    orderSecurityService.filterInaccessibleOrders(orders);
 
-    // The permission service should be called only one time, despite having 3 requisitions, due
+    // The permission service should be called only one time, despite having 3 orders, due
     // to caching
     verify(permissionService, times(1)).canViewOrderOrManagePod(any(Order.class));
   }
 
   @Test
   public void shouldNotUseCachedRightIfAllCallsAreDifferent() {
-    final Order requisition = mockRequisition(UUID.randomUUID());
-    final Order requisition2 = mockRequisition(UUID.randomUUID());
-    final Order requisition3 = mockRequisition(UUID.randomUUID());
+    final Order order = mockOrder(UUID.randomUUID());
+    final Order order2 = mockOrder(UUID.randomUUID());
+    final Order order3 = mockOrder(UUID.randomUUID());
 
-    List<Order> allRequisitions = Lists.newArrayList(requisition, requisition2, requisition3);
+    List<Order> orders = Lists.newArrayList(order, order2, order3);
 
-    requisitionSecurityService.filterInaccessibleOrders(allRequisitions);
+    orderSecurityService.filterInaccessibleOrders(orders);
 
-    // The permission service should be called one time for each requisition (no cache hits)
+    // The permission service should be called one time for each order (no cache hits)
     verify(permissionService, times(3)).canViewOrderOrManagePod(any(Order.class));
   }
 
   @Test
-  public void shouldProperlyFilterAccessibleRequisitions() {
-    final Order requisition = mockRequisition(UUID.randomUUID());
-    final Order requisition2 = mockRequisition(UUID.randomUUID());
-    final Order requisition3 = mockRequisition(UUID.randomUUID());
-    final Order requisition4 = mockRequisition(UUID.randomUUID());
+  public void shouldProperlyFilterAccessibleOrders() {
+    final Order order = mockOrder(UUID.randomUUID());
+    final Order order2 = mockOrder(UUID.randomUUID());
+    final Order order3 = mockOrder(UUID.randomUUID());
+    final Order order4 = mockOrder(UUID.randomUUID());
 
     when(permissionService.canViewOrderOrManagePod(any(Order.class)))
         .thenReturn(true, false, false, true);
 
-    List<Order> allRequisitions = Lists.newArrayList(requisition, requisition2,
-        requisition3, requisition4);
-    List<Order> result = requisitionSecurityService
-        .filterInaccessibleOrders(allRequisitions);
+    List<Order> orders = Lists.newArrayList(order, order2, order3, order4);
+    List<Order> result = orderSecurityService.filterInaccessibleOrders(orders);
 
     assertEquals(2, result.size());
-    assertEquals(requisition, result.get(0));
-    assertEquals(requisition4, result.get(1));
+    assertEquals(order, result.get(0));
+    assertEquals(order4, result.get(1));
   }
 
-  private Order mockRequisition(UUID facilityId) {
-    Order requisition = new Order();
-    requisition.setSupplyingFacilityId(facilityId);
-    return requisition;
+  private Order mockOrder(UUID facilityId) {
+    Order order = new Order();
+    order.setSupplyingFacilityId(facilityId);
+    return order;
   }
 }


### PR DESCRIPTION
For places where we need to verify rights for multiple orders the caching mechanism has been introduced. Calls to reference data service are made only for Supplying Facility Id that haven't been checked already for the given batch of orders.