### PR TITLE
Create extension point on post shipment creation

### DIFF
--- a/src/main/java/org/openlmis/fulfillment/extension/point/ShipmentCreatePostProcessor.java
+++ b/src/main/java/org/openlmis/fulfillment/extension/point/ShipmentCreatePostProcessor.java
@@ -15,11 +15,16 @@
 
 package org.openlmis.fulfillment.extension.point;
 
-public final class ExtensionPointId {
+import org.openlmis.fulfillment.domain.Shipment;
+import org.openlmis.fulfillment.service.DefaultShipmentCreatePostProcessor;
+import org.springframework.stereotype.Component;
 
-  public static final String ORDER_NUMBER_POINT_ID = "OrderNumberGenerator";
-  public static final String ORDER_CREATE_POST_POINT_ID = "OrderCreatePostProcessor";
-  public static final String SHIPMENT_CREATE_POST_POINT_ID = "ShipmentCreatePostProcessor";
+/**
+ * Extension point used for logic after creating an order.
+ * @see DefaultShipmentCreatePostProcessor
+ */
+@Component
+public interface ShipmentCreatePostProcessor {
 
-  private ExtensionPointId() { }
+  void process(Shipment shipment);
 }

--- a/src/main/java/org/openlmis/fulfillment/service/DefaultShipmentCreatePostProcessor.java
+++ b/src/main/java/org/openlmis/fulfillment/service/DefaultShipmentCreatePostProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.fulfillment.service;
+
+import org.openlmis.fulfillment.domain.Shipment;
+import org.openlmis.fulfillment.extension.point.ShipmentCreatePostProcessor;
+import org.openlmis.fulfillment.service.stockmanagement.StockEventStockManagementService;
+import org.openlmis.fulfillment.web.stockmanagement.StockEventDto;
+import org.openlmis.fulfillment.web.util.StockEventBuilder;
+import org.slf4j.ext.XLogger;
+import org.slf4j.ext.XLoggerFactory;
+import org.slf4j.profiler.Profiler;
+import org.springframework.stereotype.Component;
+
+@Component("DefaultShipmentCreatePostProcessor")
+public class DefaultShipmentCreatePostProcessor implements ShipmentCreatePostProcessor {
+
+  private static final XLogger XLOGGER = XLoggerFactory
+      .getXLogger(DefaultShipmentCreatePostProcessor.class);
+
+  private final StockEventStockManagementService stockEventService;
+
+  private final StockEventBuilder stockEventBuilder;
+
+  public DefaultShipmentCreatePostProcessor(
+      StockEventStockManagementService stockEventService,
+      StockEventBuilder stockEventBuilder) {
+    this.stockEventService = stockEventService;
+    this.stockEventBuilder = stockEventBuilder;
+  }
+
+  @Override
+  public void process(Shipment shipment) {
+    XLOGGER.entry(shipment);
+    Profiler profiler = new Profiler("DEFAULT_SHIPMENT_CREATE_POST_PROCESSOR");
+    profiler.setLogger(XLOGGER);
+
+    profiler.start("BUILD_STOCK_EVENT_FROM_SHIPMENT");
+    StockEventDto stockEventDto = stockEventBuilder.fromShipment(shipment);
+
+    profiler.start("SUBMIT_STOCK_EVENT");
+    stockEventService.submit(stockEventDto);
+
+    profiler.stop().log();
+    XLOGGER.exit();
+  }
+}

--- a/src/test/java/org/openlmis/fulfillment/web/shipment/ShipmentControllerTest.java
+++ b/src/test/java/org/openlmis/fulfillment/web/shipment/ShipmentControllerTest.java
@@ -36,9 +36,13 @@ import org.openlmis.fulfillment.domain.Order;
 import org.openlmis.fulfillment.domain.OrderStatus;
 import org.openlmis.fulfillment.domain.Shipment;
 import org.openlmis.fulfillment.domain.ShipmentDraft;
+import org.openlmis.fulfillment.extension.ExtensionManager;
+import org.openlmis.fulfillment.extension.point.ExtensionPointId;
+import org.openlmis.fulfillment.extension.point.ShipmentCreatePostProcessor;
 import org.openlmis.fulfillment.repository.OrderRepository;
 import org.openlmis.fulfillment.repository.ShipmentDraftRepository;
 import org.openlmis.fulfillment.repository.ShipmentRepository;
+import org.openlmis.fulfillment.service.DefaultShipmentCreatePostProcessor;
 import org.openlmis.fulfillment.service.PermissionService;
 import org.openlmis.fulfillment.service.ShipmentService;
 import org.openlmis.fulfillment.service.referencedata.UserDto;
@@ -86,6 +90,9 @@ public class ShipmentControllerTest {
   @Mock
   private ShipmentService shipmentService;
 
+  @Mock
+  private ExtensionManager extensionManager;
+
   @InjectMocks
   private ShipmentController shipmentController = new ShipmentController();
 
@@ -109,6 +116,10 @@ public class ShipmentControllerTest {
         .thenReturn(event);
     when(shipmentService.create(any(Shipment.class)))
         .thenReturn(shipment);
+
+    when(extensionManager.getExtension(ExtensionPointId.SHIPMENT_CREATE_POST_POINT_ID,
+        ShipmentCreatePostProcessor.class))
+        .thenReturn(new DefaultShipmentCreatePostProcessor(stockEventService, stockEventBuilder));
   }
 
   @Test


### PR DESCRIPTION
This creates an extension point after the shipment is created. The default behavior is to submit a transfer stock event.