### PR TITLE
CQI-14: Disable demo data loading for integration tests

### DIFF
--- a/src/integration-test/java/org/openlmis/fulfillment/AuditLogInitializerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/AuditLogInitializerIntegrationTest.java
@@ -52,7 +52,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@ActiveProfiles({"test", "init-audit-log"})
+@ActiveProfiles({"test", "init-audit-log", "test-run"})
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class AuditLogInitializerIntegrationTest {

--- a/src/integration-test/java/org/openlmis/fulfillment/ExposedMessageSourceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/ExposedMessageSourceIntegrationTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @SpringBootTest
 @Transactional
 public class ExposedMessageSourceIntegrationTest {

--- a/src/integration-test/java/org/openlmis/fulfillment/JaVersIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/JaVersIntegrationTest.java
@@ -38,7 +38,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @SpringBootTest
 @Transactional
 public class JaVersIntegrationTest {

--- a/src/integration-test/java/org/openlmis/fulfillment/extension/ExtensionManagerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/extension/ExtensionManagerIntegrationTest.java
@@ -24,10 +24,12 @@ import org.openlmis.fulfillment.domain.Base36EncodedOrderNumberGenerator;
 import org.openlmis.fulfillment.extension.point.OrderNumberGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test-run")
 @SuppressWarnings("PMD.UnusedLocalVariable")
 public class ExtensionManagerIntegrationTest {
 

--- a/src/integration-test/java/org/openlmis/fulfillment/repository/BaseCrudRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/repository/BaseCrudRepositoryIntegrationTest.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @DirtiesContext
 @RunWith(SpringRunner.class)
+@ActiveProfiles("test-run")
 public abstract class BaseCrudRepositoryIntegrationTest<T extends BaseEntity> {
 
   private AtomicInteger instanceNumber = new AtomicInteger(0);

--- a/src/integration-test/java/org/openlmis/fulfillment/service/ConfigurationSettingServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/service/ConfigurationSettingServiceIntegrationTest.java
@@ -32,7 +32,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootApplication(scanBasePackages = "org.openlmis.fulfillment")
 @SpringBootTest
 @TestPropertySource(properties = {"reasons.transferIn=d748d73c-cfa9-4cf0-81c6-b684f7c7e19c"})
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 public class ConfigurationSettingServiceIntegrationTest {
   private static final UUID TRANSFER_IN_REASON_ID = UUID
       .fromString("d748d73c-cfa9-4cf0-81c6-b684f7c7e19c");

--- a/src/integration-test/java/org/openlmis/fulfillment/service/JasperReportsViewServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/service/JasperReportsViewServiceIntegrationTest.java
@@ -36,10 +36,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.openlmis.fulfillment.domain.Template;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@ActiveProfiles("test-run")
 public class JasperReportsViewServiceIntegrationTest {
 
   private static final String EMPTY_REPORT_RESOURCE = "/empty-report.jrxml";

--- a/src/integration-test/java/org/openlmis/fulfillment/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/web/BaseWebIntegrationTest.java
@@ -61,11 +61,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.data.domain.Page;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("test-run")
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public abstract class BaseWebIntegrationTest {
 

--- a/src/main/java/org/openlmis/fulfillment/TestDataInitializer.java
+++ b/src/main/java/org/openlmis/fulfillment/TestDataInitializer.java
@@ -28,7 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("demo-data")
+@Profile("demo-data & !test-run")
 @Order(5)
 public class TestDataInitializer implements CommandLineRunner {
   private static final XLogger XLOGGER = XLoggerFactory.getXLogger(TestDataInitializer.class);


### PR DESCRIPTION
Demo data was previously being loaded before the tests were run, so they were affected by records fetched from a csv.