### PR TITLE
SELVSUP-43: Add Reason Assignment for Stock Event Line Item Creation …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Upcoming Version (WIP)
 ==================
 
+Improvements:
+* [SELVSUP-43](https://openlmis.atlassian.net/browse/SELVSUP-43): Add Reason Assignment for Stock Event Line Item Creation During Shipment.
+  * Introduced a new variable in the `.env` file: `SHIPMENT_REASON_ID`. Default is set to `null`; if provided, the reason will be used during shipment creation.
+  * Renamed the existing `TRANSFER_IN_REASON_ID` in the `.env` file, used in Stock Event Line Item Creation During Proof of Delivery to `POD_REASON_ID`. The default reason ID remains unchanged (`e3fc3cf3-da18-44b0-a220-77c985202e06`).
+
 9.2.0 / 2025-03-31
 ==================
 

--- a/src/integration-test/java/org/openlmis/fulfillment/service/ConfigurationSettingServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/service/ConfigurationSettingServiceIntegrationTest.java
@@ -31,17 +31,26 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootApplication(scanBasePackages = "org.openlmis.fulfillment")
 @SpringBootTest
-@TestPropertySource(properties = {"reasons.transferIn=d748d73c-cfa9-4cf0-81c6-b684f7c7e19c"})
+@TestPropertySource(properties = {
+    "reasons.pod=e3fc3cf3-da18-44b0-a220-77c985202e06",
+    "reasons.shipment=c1fc3cf3-da18-44b0-a220-77c985202e06"})
 @ActiveProfiles({"test", "test-run"})
 public class ConfigurationSettingServiceIntegrationTest {
-  private static final UUID TRANSFER_IN_REASON_ID = UUID
-      .fromString("d748d73c-cfa9-4cf0-81c6-b684f7c7e19c");
+  private static final UUID POD_REASON_ID = UUID.fromString(
+      "e3fc3cf3-da18-44b0-a220-77c985202e06");
+  private static final UUID SHIPMENT_REASON_ID = UUID.fromString(
+      "c1fc3cf3-da18-44b0-a220-77c985202e06");
 
   @Autowired
   private ConfigurationSettingService configurationSettingService;
 
   @Test
-  public void shouldReturnTransferInReasonId() {
-    assertThat(configurationSettingService.getTransferInReasonId(), is(TRANSFER_IN_REASON_ID));
+  public void shouldReturnReasonIdForProofOfDelivery() {
+    assertThat(configurationSettingService.getReasonIdForProofOfDelivery(), is(POD_REASON_ID));
+  }
+
+  @Test
+  public void shouldReturnReasonIdForShipment() {
+    assertThat(configurationSettingService.getReasonIdForShipment(), is(SHIPMENT_REASON_ID));
   }
 }

--- a/src/main/java/org/openlmis/fulfillment/service/ConfigurationSettingService.java
+++ b/src/main/java/org/openlmis/fulfillment/service/ConfigurationSettingService.java
@@ -15,6 +15,8 @@
 
 package org.openlmis.fulfillment.service;
 
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,16 +27,31 @@ import org.springframework.stereotype.Service;
 @NoArgsConstructor
 public class ConfigurationSettingService {
 
-  private static final String RESONS_SUFFIX = "reasons.";
-  static final String TRANSFER_IN = RESONS_SUFFIX + "transferIn";
+  static final String POD_REASON = "reasons.pod";
+  static final String SHIPMENT_REASON = "reasons.shipment";
   private static final String FTP_TRANSFER = "ftp.transfer.on.requisition.to.order";
   private static final String SEND_EMAIL = "send.email.on.requisition.to.order";
 
   @Autowired
   private Environment env;
 
-  public UUID getTransferInReasonId() {
-    return UUID.fromString(env.getProperty(TRANSFER_IN));
+  /**
+   * Returns reason id which should be used in proof of delivery - stock replenishment
+   * in receiving facility, by default Transfer in - e3fc3cf3-da18-44b0-a220-77c985202e06.
+   */
+  public UUID getReasonIdForProofOfDelivery() {
+    return UUID.fromString(Objects.requireNonNull(env.getProperty(POD_REASON)));
+  }
+
+  /**
+   * Returns reason id which should be used in shipment - stock consumption
+   * in supplying facility, if not present, returns null.
+   */
+  public UUID getReasonIdForShipment() {
+    return Optional.ofNullable(env.getProperty(SHIPMENT_REASON))
+        .filter(id -> !id.isEmpty())
+        .map(UUID::fromString)
+        .orElse(null);
   }
 
   public String getAllowFtpTransferOnRequisitionToOrder() {

--- a/src/main/java/org/openlmis/fulfillment/web/util/StockEventBuilder.java
+++ b/src/main/java/org/openlmis/fulfillment/web/util/StockEventBuilder.java
@@ -186,6 +186,7 @@ public class StockEventBuilder {
     StockEventLineItemDto dto = new StockEventLineItemDto();
     dto.setOccurredDate(dateHelper.getCurrentDate());
     dto.setDestinationId(destinationId);
+    dto.setReasonId(configurationSettingService.getReasonIdForShipment());
 
     final OrderableDto orderableDto = orderables.get(
         new VersionIdentityDto(lineItem.getOrderable()));
@@ -203,7 +204,7 @@ public class StockEventBuilder {
     StockEventLineItemDto dto = new StockEventLineItemDto();
     dto.setOccurredDate(proofOfDelivery.getReceivedDate());
     dto.setSourceId(sourceId);
-    dto.setReasonId(configurationSettingService.getTransferInReasonId());
+    dto.setReasonId(configurationSettingService.getReasonIdForProofOfDelivery());
 
     final OrderableDto orderableDto = orderables.get(
         new VersionIdentityDto(lineItem.getOrderable()));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,7 +60,8 @@ order.export.includeZeroQuantity=${ORDER_EXPORT_INCLUDE_ZERO_QUANTITY:false}
 cors.allowedOrigins=${CORS_ALLOWED_ORIGINS:}
 cors.allowedMethods=${CORS_ALLOWED_METHODS:}
 
-reasons.transferIn=${TRANSFER_IN_REASON_ID:e3fc3cf3-da18-44b0-a220-77c985202e06}
+reasons.pod=${POD_REASON_ID:e3fc3cf3-da18-44b0-a220-77c985202e06}
+reasons.shipment=${SHIPMENT_REASON_ID:}
 
 #why 2000 ? Check https://stackoverflow.com/a/417184
 request.maxUrlLength=2000


### PR DESCRIPTION
…During Shipment.

As in CHANGELOG:
- Introduced a new variable in the `.env` file: `SHIPMENT_REASON_ID`. Default is set to `null`; if provided, the reason will be used during shipment creation.
- Renamed the existing `TRANSFER_IN_REASON_ID` in the `.env` file, used in Stock Event Line Item Creation During Proof of Delivery to `POD_REASON_ID`. The default reason ID remains unchanged (`e3fc3cf3-da18-44b0-a220-77c985202e06`).

After confirmation the reason should be toggled (not necessarily mandatory so I decided to allow null - as it used to be). - It differs from already existing reason used in POD, but I tried to keep it as close to the existing one as possible. 
Also since any reason `implementation specific` could be used for shipment and pod processes I decided to change the naming of already existing `TRANSFER_IN_REASON_ID`.

PS: I haven't found any other use cases for `TRANSFER_IN_REASON_ID` than in Stock Event Line Item generation during POD, but please also take a closer look at it during the review. 
