### PR TITLE
SELVSUP-40: add separate Flyway migration initializer for extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-9.3.2 / WIP
+Upcoming Version / (WIP)
 ==================
 
 New functionality added in a backwards-compatible manner:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-Upcoming Version / (WIP)
+9.3.2 / WIP
 ==================
+
+New functionality added in a backwards-compatible manner:
+* Added extension Flyway migration support - extensions can now ship their own SQL migrations in `db/extension/`, tracked independently in a separate `extension_schema_version` table
 
 9.3.1 / 2026-03-02
 ==================

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ serviceName=openlmis-fulfillment
 # Only a Release Manager should update this
 # See https://openlmis.atlassian.net/wiki/display/OP/Rolling+a+Release
 ######################################################################
-serviceVersion=9.3.2-SNAPSHOT
+serviceVersion=9.4.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ serviceName=openlmis-fulfillment
 # Only a Release Manager should update this
 # See https://openlmis.atlassian.net/wiki/display/OP/Rolling+a+Release
 ######################################################################
-serviceVersion=9.4.0-SNAPSHOT
+serviceVersion=9.3.2-SNAPSHOT

--- a/src/main/java/org/openlmis/fulfillment/extension/ExtensionFlywayMigrationInitializer.java
+++ b/src/main/java/org/openlmis/fulfillment/extension/ExtensionFlywayMigrationInitializer.java
@@ -1,0 +1,87 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.fulfillment.extension;
+
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Runs extension-specific Flyway migrations after the core migrations have completed.
+ * Extensions can include SQL migration files in {@code db/extension/} on the classpath.
+ * These are tracked in a separate {@code extension_schema_version} table so that
+ * extension migrations are independent of the core migration history.
+ */
+@Component
+@DependsOn("flywayInitializer")
+public class ExtensionFlywayMigrationInitializer implements InitializingBean {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ExtensionFlywayMigrationInitializer.class);
+
+  static final String EXTENSION_LOCATION = "classpath:db/extension";
+  static final String EXTENSION_TABLE = "extension_schema_version";
+  static final String EXTENSION_DIR = "db/extension";
+
+  @Autowired
+  private DataSource dataSource;
+
+  @Value("${spring.flyway.schemas:fulfillment}")
+  private String schemaName;
+
+  /**
+   * Checks for extension migrations on the classpath and runs them if present.
+   * Does nothing when no extension migration directory is found.
+   */
+  @Override
+  public void afterPropertiesSet() {
+    if (!extensionMigrationsExist()) {
+      LOGGER.debug("No extension migrations found on classpath; skipping.");
+      return;
+    }
+
+    LOGGER.info("Extension migrations detected; running extension Flyway.");
+
+    Flyway extensionFlyway = Flyway.configure()
+        .dataSource(dataSource)
+        .schemas(schemaName)
+        .table(EXTENSION_TABLE)
+        .locations(EXTENSION_LOCATION)
+        .sqlMigrationPrefix("")
+        .placeholderPrefix("#[")
+        .placeholderSuffix("]")
+        .ignoreMissingMigrations(true)
+        .baselineOnMigrate(true)
+        .load();
+
+    int applied = extensionFlyway.migrate();
+    LOGGER.info("Extension Flyway applied {} migration(s).", applied);
+  }
+
+  /**
+   * Checks whether the extension migration directory exists on the classpath.
+   */
+  boolean extensionMigrationsExist() {
+    return new ClassPathResource(EXTENSION_DIR).exists();
+  }
+}

--- a/src/test/java/org/openlmis/fulfillment/extension/ExtensionFlywayMigrationInitializerTest.java
+++ b/src/test/java/org/openlmis/fulfillment/extension/ExtensionFlywayMigrationInitializerTest.java
@@ -1,0 +1,86 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.fulfillment.extension;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Flyway.class)
+public class ExtensionFlywayMigrationInitializerTest {
+
+  @Mock
+  private DataSource dataSource;
+
+  private ExtensionFlywayMigrationInitializer initializer;
+
+  @Before
+  public void setUp() {
+    initializer = spy(new ExtensionFlywayMigrationInitializer());
+    ReflectionTestUtils.setField(initializer, "dataSource", dataSource);
+    ReflectionTestUtils.setField(
+        initializer, "schemaName", "fulfillment");
+  }
+
+  @Test
+  public void shouldSkipWhenNoExtensionMigrationsExist() {
+    doReturn(false).when(initializer).extensionMigrationsExist();
+
+    initializer.afterPropertiesSet();
+
+    verifyNoInteractions(dataSource);
+  }
+
+  @Test
+  public void shouldRunMigrationsWhenExtensionMigrationsExist() {
+    doReturn(true).when(initializer).extensionMigrationsExist();
+
+    FluentConfiguration mockConfig =
+        mock(FluentConfiguration.class, Answers.RETURNS_SELF);
+    Flyway mockFlyway = mock(Flyway.class);
+
+    PowerMockito.mockStatic(Flyway.class);
+    PowerMockito.when(Flyway.configure()).thenReturn(mockConfig);
+    when(mockConfig.load()).thenReturn(mockFlyway);
+    when(mockFlyway.migrate()).thenReturn(1);
+
+    initializer.afterPropertiesSet();
+
+    verify(mockConfig).dataSource(dataSource);
+    verify(mockConfig).schemas("fulfillment");
+    verify(mockConfig).table(ExtensionFlywayMigrationInitializer.EXTENSION_TABLE);
+    verify(mockConfig).locations(ExtensionFlywayMigrationInitializer.EXTENSION_LOCATION);
+    verify(mockFlyway).migrate();
+  }
+
+}


### PR DESCRIPTION
  - Migrations are picked up from classpath:db/extension/                                                                                                                                                                                                                                                  
  - Tracked in a separate extension_schema_version table (independent of core history)                                                                                                                                                                                                                     
  - Runs after core migrations complete                                                                                                                                                                                                                
  - No-op when no extension is present ? fully backwards compatible                                                                                                                                                                                                           
  - baselineOnMigrate enabled so extensions can be attached/detached freely 

Tests are written, I'm not sure if they will be counted by jacoco, because they use Power Mock. 