### PR TITLE
[ODRC-66] update vvm status validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Improvements:
 * [ODRC-24](https://openlmis.atlassian.net/browse/ODRC-24) Global header and translations implemented for reports
 New functionality added in a backwards-compatible manner:
 * Added extension Flyway migration support - extensions can now ship their own SQL migrations in `db/extension/`, tracked independently in a separate `extension_schema_version` table
+* [ODRC-66](https://openlmis.atlassian.net/browse/ODRC-66) Update VVM status validator
 
 9.3.1 / 2026-03-02
 ==================

--- a/src/main/java/org/openlmis/fulfillment/domain/ProofOfDeliveryLineItem.java
+++ b/src/main/java/org/openlmis/fulfillment/domain/ProofOfDeliveryLineItem.java
@@ -120,7 +120,7 @@ public class ProofOfDeliveryLineItem extends BaseEntity {
 
     if (quantityAccepted > 0
         && useVvm
-        && (null == vvmStatus || vvmStatus.isGreaterThan(2))) {
+        && (null == vvmStatus || vvmStatus.isGreaterThan(4))) {
       throw new ValidationException(ERROR_INCORRECT_VVM_STATUS);
     }
 

--- a/src/test/java/org/openlmis/fulfillment/domain/ProofOfDeliveryLineItemTest.java
+++ b/src/test/java/org/openlmis/fulfillment/domain/ProofOfDeliveryLineItemTest.java
@@ -30,7 +30,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.openlmis.fulfillment.ProofOfDeliveryLineItemDataBuilder;
-import org.openlmis.fulfillment.domain.naming.VvmStatus;
 import org.openlmis.fulfillment.service.referencedata.OrderableDto;
 import org.openlmis.fulfillment.testutils.OrderableDataBuilder;
 import org.openlmis.fulfillment.web.ValidationException;
@@ -94,7 +93,7 @@ public class ProofOfDeliveryLineItemTest {
     exception.expectMessage(startsWith(ERROR_INCORRECT_VVM_STATUS));
     new ProofOfDeliveryLineItemDataBuilder()
         .withOrderable(orderableDto.getId(), orderableDto.getVersionNumber())
-        .withVvmStatus(VvmStatus.STAGE_4)
+        .withVvmStatus(null)
         .build()
         .validate(null, orderables);
   }


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/ODRC-66
Changes:
Enable Stage 3 and Stage 4 in the VVM status validator for the ODRC solution.