### PR TITLE
OLMIS-8244: Convert requisition-less order quantities to packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 9.4.0-SNAPSHOT (WIP)
 ==================
 
+Bug Fixes:
+* [OLMIS-8244](https://openlmis.atlassian.net/browse/OLMIS-8244): Requisition-less orders now store ordered quantity in packs - converted from doses at send time using the orderable's pack rounding configuration (`netContent`, `packRoundingThreshold`, `roundToZero`), matching requisition-based orders. Previously the ordered quantity stayed in doses and was multiplied by net content again during fulfillment (Fulfill view and order PDF), inflating the displayed quantity. Requisition-less orders already sent before this change are intentionally not migrated (their stored value is left as-is).
+
 9.3.2 / 2026-06-09
 ==================
 

--- a/src/integration-test/java/org/openlmis/fulfillment/web/OrderControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/fulfillment/web/OrderControllerIntegrationTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -68,6 +69,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.openlmis.fulfillment.OrderDataBuilder;
 import org.openlmis.fulfillment.OrderLineItemDataBuilder;
@@ -640,7 +642,13 @@ public class OrderControllerIntegrationTest extends BaseWebIntegrationTest {
     ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
     verify(orderService, times(1))
         .updateOrder(eq(firstOrderDto.getId()), any(OrderDto.class), eq(user.getId()));
+    verify(orderService, times(1)).convertOrderedQuantitiesToPacks(any(Order.class));
     verify(orderRepository, times(1)).save(orderCaptor.capture());
+
+    // doses -> packs conversion must run before the order is saved
+    InOrder inOrder = inOrder(orderService, orderRepository);
+    inOrder.verify(orderService).convertOrderedQuantitiesToPacks(any(Order.class));
+    inOrder.verify(orderRepository).save(any(Order.class));
 
     assertEquals(orderCaptor.getAllValues().size(), 1);
     assertThat(orderCaptor.getAllValues().get(0).getStatus(), is(OrderStatus.ORDERED));

--- a/src/main/java/org/openlmis/fulfillment/domain/OrderLineItem.java
+++ b/src/main/java/org/openlmis/fulfillment/domain/OrderLineItem.java
@@ -56,6 +56,8 @@ public class OrderLineItem extends BaseEntity {
   @Getter
   private VersionEntityReference orderable;
 
+  // Requisition-based orders store this in packs. Requisition-less orders store it in dispensing
+  // units (doses) until OrderService#convertOrderedQuantitiesToPacks converts it to packs at send.
   @Column(nullable = false)
   @Getter
   @Setter

--- a/src/main/java/org/openlmis/fulfillment/i18n/MessageKeys.java
+++ b/src/main/java/org/openlmis/fulfillment/i18n/MessageKeys.java
@@ -29,6 +29,7 @@ public abstract class MessageKeys {
   private static final String ORDER = "order";
   private static final String ORDER_RETRY = "orderRetry";
   private static final String ORDER_UPDATE = "orderUpdate";
+  private static final String ORDER_REQUISITION_LESS = "orderRequisitionLess";
   private static final String ORDER_FILE_TEMPLATE = "fileTemplate";
   private static final String REFERENCE_DATA = "referenceData";
   private static final String REPORTING = "reporting";
@@ -104,6 +105,9 @@ public abstract class MessageKeys {
 
   public static final String ORDER_UPDATE_INVALID_STATUS =
       join(ERROR_PREFIX, ORDER_UPDATE, INVALID_STATUS);
+
+  public static final String ORDER_REQUISITION_LESS_ORDERABLE_NOT_FOUND =
+      join(ERROR_PREFIX, ORDER_REQUISITION_LESS, ORDERABLES, NOT_FOUND);
 
   public static final String ERROR_ORDER_FILE_TEMPLATE_CREATION =
       join(ERROR_PREFIX, ORDER_FILE_TEMPLATE, CREATION);

--- a/src/main/java/org/openlmis/fulfillment/service/OrderService.java
+++ b/src/main/java/org/openlmis/fulfillment/service/OrderService.java
@@ -25,6 +25,7 @@ import static org.openlmis.fulfillment.domain.OrderStatus.ORDERED;
 import static org.openlmis.fulfillment.domain.OrderStatus.READY_TO_PACK;
 import static org.openlmis.fulfillment.domain.OrderStatus.SHIPPED;
 import static org.openlmis.fulfillment.domain.OrderStatus.TRANSFER_FAILED;
+import static org.openlmis.fulfillment.i18n.MessageKeys.ORDER_REQUISITION_LESS_ORDERABLE_NOT_FOUND;
 import static org.openlmis.fulfillment.i18n.MessageKeys.ORDER_UPDATE_INVALID_STATUS;
 import static org.openlmis.fulfillment.service.PermissionService.ORDERS_EDIT;
 import static org.openlmis.fulfillment.service.PermissionService.ORDERS_VIEW;
@@ -34,6 +35,7 @@ import static org.openlmis.fulfillment.service.PermissionService.SHIPMENTS_EDIT;
 import static org.openlmis.fulfillment.service.PermissionService.SHIPMENTS_VIEW;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -44,12 +46,14 @@ import javax.persistence.PersistenceContext;
 import org.javers.common.collections.Sets;
 import org.openlmis.fulfillment.domain.FtpTransferProperties;
 import org.openlmis.fulfillment.domain.Order;
+import org.openlmis.fulfillment.domain.OrderLineItem;
 import org.openlmis.fulfillment.domain.OrderNumberConfiguration;
 import org.openlmis.fulfillment.domain.OrderStatsData;
 import org.openlmis.fulfillment.domain.OrderStatus;
 import org.openlmis.fulfillment.domain.TransferProperties;
 import org.openlmis.fulfillment.domain.TransferType;
 import org.openlmis.fulfillment.domain.UpdateDetails;
+import org.openlmis.fulfillment.domain.VersionEntityReference;
 import org.openlmis.fulfillment.extension.ExtensionManager;
 import org.openlmis.fulfillment.extension.point.ExtensionPointId;
 import org.openlmis.fulfillment.extension.point.OrderCreatePostProcessor;
@@ -58,6 +62,8 @@ import org.openlmis.fulfillment.repository.OrderNumberConfigurationRepository;
 import org.openlmis.fulfillment.repository.OrderRepository;
 import org.openlmis.fulfillment.repository.TransferPropertiesRepository;
 import org.openlmis.fulfillment.service.referencedata.FacilityReferenceDataService;
+import org.openlmis.fulfillment.service.referencedata.OrderableDto;
+import org.openlmis.fulfillment.service.referencedata.OrderableReferenceDataService;
 import org.openlmis.fulfillment.service.referencedata.PeriodReferenceDataService;
 import org.openlmis.fulfillment.service.referencedata.PermissionStrings;
 import org.openlmis.fulfillment.service.referencedata.ProcessingPeriodDto;
@@ -70,6 +76,7 @@ import org.openlmis.fulfillment.web.NumberOfOrdersData;
 import org.openlmis.fulfillment.web.OrderNotFoundException;
 import org.openlmis.fulfillment.web.ValidationException;
 import org.openlmis.fulfillment.web.util.OrderDto;
+import org.openlmis.fulfillment.web.util.VersionIdentityDto;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,6 +104,9 @@ public class OrderService {
 
   @Autowired
   private FacilityReferenceDataService facilityReferenceDataService;
+
+  @Autowired
+  private OrderableReferenceDataService orderableReferenceDataService;
 
   @Autowired
   private OrderNumberConfigurationRepository orderNumberConfigurationRepository;
@@ -180,6 +190,44 @@ public class OrderService {
 
     XLOGGER.debug("Updated requisition-less order with id: {}", toUpdate.getId());
     return toUpdate;
+  }
+
+  /**
+   * Converts the ordered quantities of a requisition-less order from dispensing units (doses) to
+   * packs, applying each orderable's pack rounding configuration - so the stored quantity matches
+   * the packs contract used by requisition-based orders and by all fulfillment consumers. No-op for
+   * requisition-based orders (externalId set), which already carry packs.
+   *
+   * @param order the order whose line item quantities should be converted in place
+   */
+  public void convertOrderedQuantitiesToPacks(Order order) {
+    if (order.getExternalId() != null) {
+      // defense-in-depth: only requisition-less orders store ordered quantity in doses;
+      // packsToOrder is not idempotent, so it must never run on a requisition-based (packs) order
+      return;
+    }
+
+    List<OrderLineItem> lineItems = order.getOrderLineItems();
+    if (isEmpty(lineItems)) {
+      return;
+    }
+
+    Set<VersionEntityReference> identities = lineItems.stream()
+        .map(OrderLineItem::getOrderable)
+        .collect(Collectors.toSet());
+
+    Map<VersionIdentityDto, OrderableDto> orderables = orderableReferenceDataService
+        .findByIdentities(identities)
+        .stream()
+        .collect(Collectors.toMap(OrderableDto::getIdentity, orderable -> orderable));
+
+    for (OrderLineItem lineItem : lineItems) {
+      OrderableDto orderable = orderables.get(new VersionIdentityDto(lineItem.getOrderable()));
+      if (null == orderable) {
+        throw new ValidationException(ORDER_REQUISITION_LESS_ORDERABLE_NOT_FOUND);
+      }
+      lineItem.setOrderedQuantity(orderable.packsToOrder(lineItem.getOrderedQuantity()));
+    }
   }
 
   /**

--- a/src/main/java/org/openlmis/fulfillment/service/OrderService.java
+++ b/src/main/java/org/openlmis/fulfillment/service/OrderService.java
@@ -148,7 +148,10 @@ public class OrderService {
   }
 
   /**
-   * Creates requisition-less order.
+   * Creates requisition-less order. The ordered quantities are stored as received, i.e. in
+   * dispensing units (doses); they are converted to packs by
+   * {@link #convertOrderedQuantitiesToPacks(Order)} at send time. Until then a requisition-less
+   * order's line item quantities are NOT in the packs unit that the rest of fulfillment assumes.
    *
    * @param orderDto object that order will be created from.
    * @return created Order.
@@ -222,9 +225,16 @@ public class OrderService {
         .collect(Collectors.toMap(OrderableDto::getIdentity, orderable -> orderable));
 
     for (OrderLineItem lineItem : lineItems) {
+      if (null == lineItem.getOrderedQuantity()) {
+        // OrderValidator rejects null quantities before send; skip defensively so a caller that
+        // bypasses validation does not hit an NPE when unboxing into packsToOrder(long)
+        continue;
+      }
+
       OrderableDto orderable = orderables.get(new VersionIdentityDto(lineItem.getOrderable()));
       if (null == orderable) {
-        throw new ValidationException(ORDER_REQUISITION_LESS_ORDERABLE_NOT_FOUND);
+        throw new ValidationException(ORDER_REQUISITION_LESS_ORDERABLE_NOT_FOUND,
+            lineItem.getOrderable().getId().toString());
       }
       lineItem.setOrderedQuantity(orderable.packsToOrder(lineItem.getOrderedQuantity()));
     }

--- a/src/main/java/org/openlmis/fulfillment/service/referencedata/OrderableDto.java
+++ b/src/main/java/org/openlmis/fulfillment/service/referencedata/OrderableDto.java
@@ -53,6 +53,34 @@ public class OrderableDto extends BaseDto {
     return null != extraData && parseBoolean(extraData.get(USE_VVM));
   }
 
+  /**
+   * Returns the number of packs to order. For this Orderable given a desired number of
+   * dispensing units, will return the number of packs that should be ordered. Canonical
+   * implementation lives in referencedata Orderable#packsToOrder (also mirrored in requisition's
+   * BasicOrderableDto) - keep this copy byte-identical.
+   *
+   * @param dispensingUnits # of dispensing units we'd like to order for
+   * @return the number of packs that should be ordered.
+   */
+  public long packsToOrder(long dispensingUnits) {
+    if (dispensingUnits <= 0 || netContent == 0) {
+      return 0;
+    }
+
+    long packsToOrder = dispensingUnits / netContent;
+    long remainderQuantity = dispensingUnits % netContent;
+
+    if (remainderQuantity > 0 && remainderQuantity > packRoundingThreshold) {
+      packsToOrder += 1;
+    }
+
+    if (packsToOrder == 0 && !roundToZero) {
+      packsToOrder = 1;
+    }
+
+    return packsToOrder;
+  }
+
   @JsonIgnore
   public Long getVersionNumber() {
     return meta.getVersionNumber();

--- a/src/main/java/org/openlmis/fulfillment/web/OrderController.java
+++ b/src/main/java/org/openlmis/fulfillment/web/OrderController.java
@@ -261,6 +261,7 @@ public class OrderController extends BaseController {
     UUID userId = currentUser == null ? orderDto.getLastUpdater().getId() : currentUser.getId();
 
     Order order = orderService.updateOrder(orderId, orderDto, userId);
+    orderService.convertOrderedQuantitiesToPacks(order);
     order.prepareToLocalFulfill();
 
     orderRepository.save(order);

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -67,6 +67,7 @@ fulfillment.error.order.invalidStatus=The provided order status is not a valid s
 fulfillment.error.order.notFoundOrWrongStatus=Unable to find an orders or wrong status for IDs: {0}
 
 fulfillment.error.orderUpdate.invalidStatus=Incorrect order status. You can manually update only orders with CREATING status
+fulfillment.error.orderRequisitionLess.orderables.notFound=Orderable not found for a requisition-less order line item during send
 
 # Order retry errors
 fulfillment.error.orderRetry.invalidStatus=Incorrect order status. You can manually retry only orders with TRANSFER_FAILED status

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -67,7 +67,7 @@ fulfillment.error.order.invalidStatus=The provided order status is not a valid s
 fulfillment.error.order.notFoundOrWrongStatus=Unable to find an orders or wrong status for IDs: {0}
 
 fulfillment.error.orderUpdate.invalidStatus=Incorrect order status. You can manually update only orders with CREATING status
-fulfillment.error.orderRequisitionLess.orderables.notFound=Orderable not found for a requisition-less order line item during send
+fulfillment.error.orderRequisitionLess.orderables.notFound=Orderable {0} not found for a requisition-less order line item during send
 
 # Order retry errors
 fulfillment.error.orderRetry.invalidStatus=Incorrect order status. You can manually retry only orders with TRANSFER_FAILED status

--- a/src/test/java/org/openlmis/fulfillment/service/OrderServiceTest.java
+++ b/src/test/java/org/openlmis/fulfillment/service/OrderServiceTest.java
@@ -496,6 +496,72 @@ public class OrderServiceTest {
     assertEquals(numberOfStatuses, result.getStatusesStats().size());
   }
 
+  @Test
+  public void shouldConvertOrderedQuantitiesToPacksForRequisitionLessOrder() {
+    // given - a requisition-less order (no externalId) with quantity in doses
+    OrderableDto orderableDto = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(0)
+        .withRoundToZero(false)
+        .build();
+    OrderLineItem lineItem = new OrderLineItemDataBuilder()
+        .withOrderable(orderableDto.getId(), orderableDto.getVersionNumber())
+        .withOrderedQuantity(23L)
+        .build();
+    Order reqlessOrder = new OrderDataBuilder()
+        .withExternalId(null)
+        .withLineItems(lineItem)
+        .build();
+    when(orderableReferenceDataService.findByIdentities(anySet()))
+        .thenReturn(Collections.singletonList(orderableDto));
+
+    // when
+    orderService.convertOrderedQuantitiesToPacks(reqlessOrder);
+
+    // then - 23 doses -> 3 packs (rounded up, threshold 0)
+    assertEquals(Long.valueOf(3), lineItem.getOrderedQuantity());
+  }
+
+  @Test
+  public void shouldNotConvertOrderedQuantitiesForRequisitionBasedOrder() {
+    // given - an order with externalId (requisition-based), quantity already in packs
+    OrderLineItem lineItem = new OrderLineItemDataBuilder()
+        .withOrderedQuantity(5L)
+        .build();
+    Order requisitionOrder = new OrderDataBuilder()
+        .withExternalId(UUID.randomUUID())
+        .withLineItems(lineItem)
+        .build();
+
+    // when
+    orderService.convertOrderedQuantitiesToPacks(requisitionOrder);
+
+    // then - quantity unchanged, no orderable lookup performed
+    assertEquals(Long.valueOf(5), lineItem.getOrderedQuantity());
+    verify(orderableReferenceDataService, never()).findByIdentities(anySet());
+  }
+
+  @Test
+  public void shouldThrowWhenOrderableNotFoundDuringConversion() {
+    // given
+    OrderableDto orderableDto = new OrderableDataBuilder().build();
+    OrderLineItem lineItem = new OrderLineItemDataBuilder()
+        .withOrderable(orderableDto.getId(), orderableDto.getVersionNumber())
+        .withOrderedQuantity(23L)
+        .build();
+    Order reqlessOrder = new OrderDataBuilder()
+        .withExternalId(null)
+        .withLineItems(lineItem)
+        .build();
+    when(orderableReferenceDataService.findByIdentities(anySet())).thenReturn(emptyList());
+
+    // then
+    exception.expect(ValidationException.class);
+
+    // when
+    orderService.convertOrderedQuantitiesToPacks(reqlessOrder);
+  }
+
   private Order generateOrder() {
     return new OrderDataBuilder().withOrderedStatus().build();
   }

--- a/src/test/java/org/openlmis/fulfillment/service/OrderServiceTest.java
+++ b/src/test/java/org/openlmis/fulfillment/service/OrderServiceTest.java
@@ -562,6 +562,57 @@ public class OrderServiceTest {
     orderService.convertOrderedQuantitiesToPacks(reqlessOrder);
   }
 
+  @Test
+  public void shouldConvertEachLineItemUsingItsOwnOrderableConfig() {
+    // given - two orderables with different net content
+    OrderableDto first = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(0)
+        .withRoundToZero(false)
+        .build();
+    OrderableDto second = new OrderableDataBuilder()
+        .withNetContent(25)
+        .withPackRoundingThreshold(0)
+        .withRoundToZero(false)
+        .build();
+    OrderLineItem firstLine = new OrderLineItemDataBuilder()
+        .withOrderable(first.getId(), first.getVersionNumber())
+        .withOrderedQuantity(23L)
+        .build();
+    OrderLineItem secondLine = new OrderLineItemDataBuilder()
+        .withOrderable(second.getId(), second.getVersionNumber())
+        .withOrderedQuantity(30L)
+        .build();
+    Order reqlessOrder = new OrderDataBuilder()
+        .withExternalId(null)
+        .withLineItems(firstLine, secondLine)
+        .build();
+    when(orderableReferenceDataService.findByIdentities(anySet()))
+        .thenReturn(asList(first, second));
+
+    // when
+    orderService.convertOrderedQuantitiesToPacks(reqlessOrder);
+
+    // then - each line converted with its own net content (23/10 -> 3, 30/25 -> 2)
+    assertEquals(Long.valueOf(3), firstLine.getOrderedQuantity());
+    assertEquals(Long.valueOf(2), secondLine.getOrderedQuantity());
+  }
+
+  @Test
+  public void shouldNotLookUpOrderablesWhenRequisitionLessOrderHasNoLineItems() {
+    // given
+    Order reqlessOrder = new OrderDataBuilder()
+        .withExternalId(null)
+        .withoutLineItems()
+        .build();
+
+    // when
+    orderService.convertOrderedQuantitiesToPacks(reqlessOrder);
+
+    // then
+    verify(orderableReferenceDataService, never()).findByIdentities(anySet());
+  }
+
   private Order generateOrder() {
     return new OrderDataBuilder().withOrderedStatus().build();
   }

--- a/src/test/java/org/openlmis/fulfillment/service/referencedata/OrderableDtoTest.java
+++ b/src/test/java/org/openlmis/fulfillment/service/referencedata/OrderableDtoTest.java
@@ -67,6 +67,18 @@ public class OrderableDtoTest {
   }
 
   @Test
+  public void packsToOrderShouldNotRoundUpWhenRemainderEqualsThreshold() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(3)
+        .withRoundToZero(false)
+        .build();
+
+    // remainder 3 == threshold 3, and the comparison is strict '>', so no round-up
+    assertEquals(2L, orderable.packsToOrder(23));
+  }
+
+  @Test
   public void packsToOrderShouldRoundToOneWhenResultZeroAndRoundToZeroFalse() {
     OrderableDto orderable = new OrderableDataBuilder()
         .withNetContent(10)

--- a/src/test/java/org/openlmis/fulfillment/service/referencedata/OrderableDtoTest.java
+++ b/src/test/java/org/openlmis/fulfillment/service/referencedata/OrderableDtoTest.java
@@ -15,9 +15,12 @@
 
 package org.openlmis.fulfillment.service.referencedata;
 
+import static org.junit.Assert.assertEquals;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.openlmis.fulfillment.testutils.OrderableDataBuilder;
 
 public class OrderableDtoTest {
 
@@ -28,5 +31,79 @@ public class OrderableDtoTest {
         .suppress(Warning.STRICT_INHERITANCE) // suppress class not final
         .suppress(Warning.NONFINAL_FIELDS)
         .verify();
+  }
+
+  @Test
+  public void packsToOrderShouldReturnPacksForExactMultiple() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(0)
+        .withRoundToZero(false)
+        .build();
+
+    assertEquals(2L, orderable.packsToOrder(20));
+  }
+
+  @Test
+  public void packsToOrderShouldRoundUpWhenRemainderExceedsThreshold() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(0)
+        .withRoundToZero(false)
+        .build();
+
+    assertEquals(3L, orderable.packsToOrder(23));
+  }
+
+  @Test
+  public void packsToOrderShouldNotRoundUpWhenRemainderWithinThreshold() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(5)
+        .withRoundToZero(false)
+        .build();
+
+    assertEquals(2L, orderable.packsToOrder(23));
+  }
+
+  @Test
+  public void packsToOrderShouldRoundToOneWhenResultZeroAndRoundToZeroFalse() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(5)
+        .withRoundToZero(false)
+        .build();
+
+    assertEquals(1L, orderable.packsToOrder(3));
+  }
+
+  @Test
+  public void packsToOrderShouldRoundToZeroWhenResultZeroAndRoundToZeroTrue() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(10)
+        .withPackRoundingThreshold(5)
+        .withRoundToZero(true)
+        .build();
+
+    assertEquals(0L, orderable.packsToOrder(3));
+  }
+
+  @Test
+  public void packsToOrderShouldReturnZeroForZeroNetContent() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(0)
+        .build();
+
+    assertEquals(0L, orderable.packsToOrder(10));
+  }
+
+  @Test
+  public void packsToOrderShouldReturnZeroForNonPositiveQuantity() {
+    OrderableDto orderable = new OrderableDataBuilder()
+        .withNetContent(10)
+        .build();
+
+    assertEquals(0L, orderable.packsToOrder(0));
+    assertEquals(0L, orderable.packsToOrder(-5));
   }
 }

--- a/src/test/java/org/openlmis/fulfillment/testutils/OrderableDataBuilder.java
+++ b/src/test/java/org/openlmis/fulfillment/testutils/OrderableDataBuilder.java
@@ -81,6 +81,16 @@ public class OrderableDataBuilder {
     return this;
   }
 
+  public OrderableDataBuilder withPackRoundingThreshold(long packRoundingThreshold) {
+    this.packRoundingThreshold = packRoundingThreshold;
+    return this;
+  }
+
+  public OrderableDataBuilder withRoundToZero(boolean roundToZero) {
+    this.roundToZero = roundToZero;
+    return this;
+  }
+
   public OrderableDataBuilder withVersionNumber(Long versionNumber) {
     this.versionNumber = versionNumber;
     return this;


### PR DESCRIPTION
## OLMIS-8244 — Requisition-less order quantity inflated by net content

Ticket: https://openlmis.atlassian.net/browse/OLMIS-8244

### Problem
A requisition-less order stored `orderedQuantity` in **dispensing units (doses)**, while every
downstream consumer treats `orderedQuantity` as **packs** (the system-wide contract since OLMIS-3958,
which also introduced `totalDispensingUnits = orderedQuantity * netContent`). So for a requisition-less
order the value was multiplied by `netContent` a second time, inflating the printed order PDF
(`totalDispensingUnits`) and the Fulfill / shipment view. Requisition-based orders were already correct
(they store `packsToShip`).

### Fix
Convert the requisition-less order line quantities from doses to packs **at send**
(`OrderController.sendRequisitionLessOrder`), so `orderedQuantity` is stored in packs — the same unit
every consumer expects — and all three consumers (order PDF, REST DTO, Fulfill view) become correct
without touching them.

- `OrderableDto.packsToOrder(long)` — pack-rounding identical to the canonical referencedata
  `Orderable#packsToOrder` (and requisition `BasicOrderableDto`), with an anti-drift comment.
- `OrderService.convertOrderedQuantitiesToPacks(Order)` — runs only for requisition-less orders
  (`externalId == null`; defence-in-depth guard because `packsToOrder` is not idempotent), batch-fetches
  the version-correct orderables (no N+1), and rewrites each line's quantity to packs.
- Conversion happens **only at send**, not at create/update, so drafts stay in doses and the
  requisition-less edit screen stays consistent.
- Guard against a null ordered quantity; include the failing orderable id in the not-found message; document the doses-until-send invariant

### Notes
- No DB migration / Flyway change — `netContent`, `packRoundingThreshold`, `roundToZero` already live
  in referencedata and are fetched at runtime; the `orderedQuantity` column is reused.
- Existing already-sent requisition-less orders are **not** back-filled (cosmetic historical gap; agreed).
- UI companion PRs add a "Will be ordered as X pack(s)" preview so the user sees the rounded result
  before sending: openlmis-ui-components (preview hint) + openlmis-requisition-ui (wire-up).

### Tests
- `OrderableDtoTest` — 8 cases for packsToOrder (exact, round-up above threshold, round-down within threshold, round-down at the exact threshold boundary, sub-pack min-1, roundToZero, zero net content, non-positive quantity).
- `OrderServiceTest` — convert requisition-less (single + multi-line, each using its own orderable config), no-op for requisition-based, no-op for empty line items, throw when orderable not found.

### E2E verified (live ref-distro, full production path)
- Send converts: 130 doses → 2 packs / 168 dispensing units; 252 → 3 / 252; multi-line independent
  (130→2 + 18→4); roundToZero product 1 dose → 0.
- Requisition-based order unchanged (100/8400, 50/3150).
- Order PDF and Fulfill view both show the converted packs.
