### PR TITLE
MW-1471: Activate Prometheus metrics endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ repositories {
 
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "io.micrometer:micrometer-registry-prometheus"
     compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"
     compile "org.projectlombok:lombok"

--- a/src/main/java/org/openlmis/fulfillment/security/ResourceServerSecurityConfiguration.java
+++ b/src/main/java/org/openlmis/fulfillment/security/ResourceServerSecurityConfiguration.java
@@ -86,6 +86,7 @@ public class ResourceServerSecurityConfiguration implements ResourceServerConfig
         .authorizeRequests()
         .antMatchers(
             "/actuator/health",
+            "/actuator/prometheus",
             "/fulfillment",
             "/webjars/**",
             "/fulfillment/webjars/**",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,8 @@ spring.jpa.properties.hibernate.order_inserts=true
 
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
-management.endpoints.web.exposure.include=health
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health,prometheus
 
 server.compression.enabled=true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css


### PR DESCRIPTION
Activates the Prometheus (Micrometer) actuator endpoint so JVM/HTTP metrics can be scraped by a Grafana Alloy agent (OpenLMIS Malawi monitoring). build.gradle adds micrometer-registry-prometheus (+ actuator starter where missing); application.properties exposes (and, where enabled-by-default=false, enables) the prometheus endpoint; ResourceServerSecurityConfiguration permits /actuator/prometheus (like the existing /actuator/health). Only reachable on the internal network in the Malawi deployment (service ports not host-published; nginx routes /api/* only). Verified: builds, boots, GET /actuator/prometheus returns 200 with JVM/HTTP metrics. A companion hotfix branch rel-9.2.0-hotfix.1 carries the same activation on the deployed line.